### PR TITLE
Updated pip version from 19.3.1 to 21.3.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - mafft
   - medaka=0.10.0
   - minimap2=2.17
-  - pip=19.3.1
+  - pip=21.3.1
   - python=3.6
   - snakemake-minimal=5.10
   - racon=1.4.7


### PR DESCRIPTION
I encountered an error while building realtime-polio that I believe is related to a Python version conflict. 

The error message was: `"ERROR: Package 'Markdown' requires a different Python: 3.6.10 not in '>=3.7'"`. After investigating the error log and testing some different scenarios, I found a solution that worked for me. When I updated the pip version from 19.3.1 to 21.3.1, the conflict was resolved.

I understand that this project is deprecated, but I still wanted to provide a solution for anyone who might still be using it. I've submitted a pull request with the updated pip version. Please let me know if you have any feedback or concerns about this solution. I'm happy to make any necessary changes.